### PR TITLE
feat: Support index

### DIFF
--- a/deeppavlov_kg/core/graph.py
+++ b/deeppavlov_kg/core/graph.py
@@ -880,8 +880,8 @@ class Neo4jKnowledgeGraph(KnowledgeGraph):
 class TerminusdbKnowledgeGraph(KnowledgeGraph):
     def __init__(
         self,
-        team: str,
         db_name: str,
+        team: str = "",
         server: Optional[str] = None,
         local: bool = False,
         username: str = "admin",
@@ -903,6 +903,8 @@ class TerminusdbKnowledgeGraph(KnowledgeGraph):
                 self._client.connect(key=password)
                 self._client.create_database(self._db)
         else:
+            if not self._team:
+                raise ValueError("team argument should be passed when you're connecting to local or cloud")
             if local:
                 self._client = WOQLClient("http://localhost:6363", account=username, team=self._team, key=password)
                 try:

--- a/deeppavlov_kg/core/graph.py
+++ b/deeppavlov_kg/core/graph.py
@@ -917,6 +917,7 @@ class TerminusdbKnowledgeGraph(KnowledgeGraph):
                 except InterfaceError:
                     self._client.connect(team=self._team, use_token=True)
                     self._client.create_database(db_name)
+        logger.info("Connected to the database")
         self.ontology = TerminusdbOntologyConfig(self._client, self)
 
     def drop_database(self):

--- a/deeppavlov_kg/core/graph.py
+++ b/deeppavlov_kg/core/graph.py
@@ -921,15 +921,18 @@ class TerminusdbKnowledgeGraph(KnowledgeGraph):
         self.ontology = TerminusdbOntologyConfig(self._client, self)
 
     def drop_database(self):
-        """Clears the database from ontology and knowledge graphs."""
-        DB = self._client.db
-        TEAM = self._client.team
-        self._client.delete_database(DB, team=TEAM)
-        self._client.create_database(DB, team=TEAM)
-        logger.info("Database was recreated successfully")
-        self.ontology.init_abstract_kind()
-        logger.info("Abstract kind has been initialized")
-
+        """Clears only the knowledge graph database keeping the ontology withou change."""
+        query = WOQL().quad(
+            "v:a", "v:r", "v:b", "instance"
+        ).woql_not(
+            WOQL().quad("v:a", "rdf:type", "@schema:Abstract", "instance")
+        ).delete_quad(
+            "v:a", "v:r", "v:b", "instance"
+        )
+        results = query.execute(self._client)
+        if results == "Commit successfully made.":
+            logger.info("Graph database was cleared successfully")
+        return results
 
     def create_entities(self, entity_kinds: List[str], entity_ids: List[str], property_kinds: Optional[List[List[str]]] = None, property_values: Optional[List[List[Any]]] = None):
         """create an entity, or rewrite above it if it exists"""

--- a/deeppavlov_kg/core/index.py
+++ b/deeppavlov_kg/core/index.py
@@ -1,0 +1,63 @@
+import logging
+import os
+import sqlite3
+
+logging.basicConfig(format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+class Index:
+    def __init__(self, load_path):
+        self.load_path = load_path
+        self.user_id = None
+        self.load()
+        logger.info(f"Index was loaded. Found in path {load_path}")
+
+    def load(self) -> None:
+        if not os.path.exists(self.load_path):
+            os.makedirs(self.load_path)
+        self.conn = sqlite3.connect(str(self.load_path / "custom_database.db"), check_same_thread=False)
+        self.cur = self.conn.cursor()
+        self.cur.execute("CREATE VIRTUAL TABLE IF NOT EXISTS inverted_index USING fts5(title, entity_id, num_rels "
+                         "UNINDEXED, tag, user_id, tokenize = 'porter ascii');")
+
+    def drop_index(self) -> None:
+        if os.path.exists(self.load_path / "custom_database.db"):
+            os.remove(self.load_path / "custom_database.db")
+            logger.info("Index was cleared successfully")
+            self.load()
+
+    def add_entities(self, entity_substr_list, entity_ids_list, tags_list):
+        assert self.user_id is not None, "Active user_id should be defined. Use set_active_user_id method" #TODO: think about not adding abstract inctances to index
+        logger.debug("inside add_custom_entities ---")
+        if self.conn is None:
+            logger.debug("inside add_custom_entities --- inside if")
+            if not os.path.exists(self.load_path):
+                os.makedirs(self.load_path)
+            self.conn = sqlite3.connect(str(self.load_path / "custom_database.db"), check_same_thread=False)
+            self.cur = self.conn.cursor()
+            self.cur.execute("CREATE VIRTUAL TABLE IF NOT EXISTS inverted_index USING fts5(title, entity_id, num_rels "
+                             "UNINDEXED, tag, user_id, tokenize = 'porter ascii');")
+
+        for entity_substr, entity_id, tag in zip(entity_substr_list, entity_ids_list, tags_list):
+            logger.debug("inside add_custom_entities --- inside for")
+            entity_id = entity_id.replace("/", "slash").replace("-", "hyphen")
+            query_str = f"title:{entity_substr} AND tag:{tag} AND user_id:{self.user_id}"
+
+            query = "SELECT * FROM inverted_index WHERE inverted_index MATCH ?;"
+            res = self.cur.execute(query, (query_str,)).fetchall()
+            logger.debug(f"the result is {res}")
+            if res and res[0][3] == "name" and res[0][1] == entity_id and tag == "name":
+                query = "DELETE FROM inverted_index WHERE entity_id=? AND tag=? AND user_id=?;"
+                self.cur.execute(query, (entity_id, tag, self.user_id))
+                self.cur.execute("INSERT INTO inverted_index "
+                                 "VALUES (?, ?, ?, ?, ?);", (entity_substr.lower(), entity_id, 1, tag, self.user_id))
+                self.conn.commit()
+                logger.debug("deleted and posted")
+            elif not res:
+                self.cur.execute("INSERT INTO inverted_index "
+                                 "VALUES (?, ?, ?, ?, ?);", (entity_substr.lower(), entity_id, 1, tag, self.user_id))
+                self.conn.commit()
+                logger.debug("Just posted")
+
+    def set_active_user_id(self, user_id: str):
+        self.user_id = user_id

--- a/deeppavlov_kg/core/index.py
+++ b/deeppavlov_kg/core/index.py
@@ -28,6 +28,7 @@ class Index:
 
     def add_entities(self, entity_substr_list, entity_ids_list, tags_list):
         assert self.user_id is not None, "Active user_id should be defined. Use set_active_user_id method" #TODO: think about not adding abstract inctances to index
+        user_id = self.user_id.replace("/", "slash").replace("-", "hyphen")
         logger.debug("inside add_custom_entities ---")
         if self.conn is None:
             logger.debug("inside add_custom_entities --- inside if")
@@ -41,21 +42,21 @@ class Index:
         for entity_substr, entity_id, tag in zip(entity_substr_list, entity_ids_list, tags_list):
             logger.debug("inside add_custom_entities --- inside for")
             entity_id = entity_id.replace("/", "slash").replace("-", "hyphen")
-            query_str = f"title:{entity_substr} AND tag:{tag} AND user_id:{self.user_id}"
+            query_str = f"title:{entity_substr} AND tag:{tag} AND user_id:{user_id}"
 
             query = "SELECT * FROM inverted_index WHERE inverted_index MATCH ?;"
             res = self.cur.execute(query, (query_str,)).fetchall()
             logger.debug(f"the result is {res}")
             if res and res[0][3] == "name" and res[0][1] == entity_id and tag == "name":
                 query = "DELETE FROM inverted_index WHERE entity_id=? AND tag=? AND user_id=?;"
-                self.cur.execute(query, (entity_id, tag, self.user_id))
+                self.cur.execute(query, (entity_id, tag, user_id))
                 self.cur.execute("INSERT INTO inverted_index "
-                                 "VALUES (?, ?, ?, ?, ?);", (entity_substr.lower(), entity_id, 1, tag, self.user_id))
+                                 "VALUES (?, ?, ?, ?, ?);", (entity_substr.lower(), entity_id, 1, tag, user_id))
                 self.conn.commit()
                 logger.debug("deleted and posted")
             elif not res:
                 self.cur.execute("INSERT INTO inverted_index "
-                                 "VALUES (?, ?, ?, ?, ?);", (entity_substr.lower(), entity_id, 1, tag, self.user_id))
+                                 "VALUES (?, ?, ?, ?, ?);", (entity_substr.lower(), entity_id, 1, tag, user_id))
                 self.conn.commit()
                 logger.debug("Just posted")
 

--- a/deeppavlov_kg/core/ontology.py
+++ b/deeppavlov_kg/core/ontology.py
@@ -791,6 +791,16 @@ class TerminusdbOntologyConfig(OntologyConfig):
                     #return a list of parents not only the last appended one )
         return pretty_results
 
+    def drop_database(self):
+        """Clears the database from ontology and knowledge graphs."""
+        DB = self._client.db
+        TEAM = self._client.team
+        self._client.delete_database(DB, team=TEAM)
+        self._client.create_database(DB, team=TEAM)
+        logger.info("Database was recreated successfully")
+        self.init_abstract_kind()
+        logger.info("Abstract kind has been initialized")
+
     def create_entity_kinds(self, entity_kinds: List[str], parents: Optional[List[Union[str, None]]] = None):
         """Creates entity kinds and adds each kind as instance of 'Abstract' kind.
 

--- a/deeppavlov_kg/core/ontology.py
+++ b/deeppavlov_kg/core/ontology.py
@@ -641,6 +641,7 @@ class TerminusdbOntologyConfig(OntologyConfig):
         self.kg = kg
         if self._client.get_class_frame("Abstract").get("Name") is None:
             self.init_abstract_kind()
+            logger.info("Abstract kind has been initialized")
 
     def init_abstract_kind(self):
         self.create_entity_kind("Abstract") # TODO: merge it all in one-line code: create [entity_kinds, properties, relationships]
@@ -656,7 +657,7 @@ class TerminusdbOntologyConfig(OntologyConfig):
             property_values=[[kind] for kind in entity_kinds]
         )
         for kind, entity_id in zip(entity_kinds, entity_ids):
-            logger.info(f"added abstract kind --- {kind} --- {entity_id}")
+            logger.info(f"Added abstract instance --- id='{entity_id}' --- Name property='{kind}'")
         existing_parents = parents.copy()
         entity_with_parents = entity_ids.copy()
         for entity_id, parent in zip(entity_ids, parents):
@@ -815,7 +816,7 @@ class TerminusdbOntologyConfig(OntologyConfig):
 
             return abstract_kinds_instances
         elif result["api:status"] == "api:success":
-            logger.info("Abstract kind is already in database")
+            logger.info(f"Kinds '{entity_kinds}' are already in database")
         else:
             raise DatabaseError(f"failed to commit to schema, message: {result['api:status']}")
 
@@ -1067,10 +1068,10 @@ class TerminusdbOntologyConfig(OntologyConfig):
                 )
         query.execute(self._client)
         results = self.update_labels_of_property_kinds(entity_kinds_a, relationship_kinds, relationship_kind_labels)
-        for kind_a, rel_kind, label in zip(
-            entity_kinds_a, relationship_kinds, relationship_kind_labels
+        for kind_a, rel_kind, kind_b, label in zip(
+            entity_kinds_a, relationship_kinds, entity_kinds_b, relationship_kind_labels
         ):
-            logger.info(f"Created relationship kind '{kind_a}--{rel_kind}' with label '{label}' successfully")
+            logger.info(f"Created relationship kind '{kind_a}--{rel_kind}->{kind_b}' with label '{label}' successfully")
         return results
 
     def create_relationship_kind(self, entity_kind_a: str, relationship_kind: str, entity_kind_b: str):

--- a/deeppavlov_kg/core/ontology.py
+++ b/deeppavlov_kg/core/ontology.py
@@ -976,7 +976,11 @@ class TerminusdbOntologyConfig(OntologyConfig):
 
     def get_entity_kind(self, entity_kind: str):
         """Returns entity kind direct properties as well as inherited ones from parents"""
-        return self._client.get_class_frame(entity_kind)
+        try:
+            properties = self._client.get_document(entity_kind, graph_type="schema")
+        except DatabaseError as exc:
+            raise ValueError(f"Entity kind '{entity_kind}' doesn't exist in KG") from exc
+        return properties
 
     def create_property_kinds_of_entity_kinds(
         self,

--- a/deeppavlov_kg/core/ontology.py
+++ b/deeppavlov_kg/core/ontology.py
@@ -791,8 +791,13 @@ class TerminusdbOntologyConfig(OntologyConfig):
                     #return a list of parents not only the last appended one )
         return pretty_results
 
-    def drop_database(self):
+    def drop_database(self, drop_index=False): # TODO: add arg 'graph' and use it like graph.index.drop_index()
         """Clears the database from ontology and knowledge graphs."""
+        if drop_index:
+            try:
+                self.kg.index.drop_index()
+            except AttributeError:
+                raise ValueError("Index isn't loaded. Use set_index method")
         DB = self._client.db
         TEAM = self._client.team
         self._client.delete_database(DB, team=TEAM)

--- a/deeppavlov_kg/core/ontology.py
+++ b/deeppavlov_kg/core/ontology.py
@@ -822,6 +822,9 @@ class TerminusdbOntologyConfig(OntologyConfig):
         if parents is None:
             parents = [None]*len(entity_kinds)
 
+        entity_kinds = entity_kinds.copy()
+        parents = parents.copy()
+
         query = WOQL().woql_or(*[
             WOQL().woql_not(WOQL().quad(":".join(["@schema", entity_kind]), "rdf:type", "sys:Class", "schema")).add_quad(
             ":".join(["@schema", entity_kind]), "rdf:type", "sys:Class", "schema"

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,18 @@ authors = [
     "Maxim Talimanchuk <mtalimanchuk@gmail.com>",
 ]
 
-with open("requirements.txt", "r", encoding="utf-8") as req_f:
-    install_requires = [line.strip() for line in req_f if line.strip()]
+# with open("requirements.txt", "r", encoding="utf-8") as req_f:
+#     install_requires = [line.strip() for line in req_f if line.strip()]
+
+install_requires = [
+    "neomodel==4.0.8",
+    "pydantic[dotenv]==1.9.0",
+    "fabulist==1.2.0",
+    "mimesis==5.3.0",
+    "pylint==2.13.8",
+    "treelib==1.6.1",
+    "terminusdb_client @ git+https://github.com/deeppavlov/terminusdb-client-python.git#egg=terminusdb_client",
+]
 
 setup(
     name="deeppavlov-kg",


### PR DESCRIPTION
* chore: reformat logs & add ones

* fix: handle creating existing-in-db entity kinds

* * Raises ValueError if at least one entity kind already exists in DB

* feat: Add droping graph database keeping ontology

* feat: Support SQL index for faster search

* fix: Make team argument optional to connect

* fix: create_entity_kinds now works even if a kind's in DB

* chore: Add logs

* fix: Use get_document for getting an entity kind

* fix: Encode symbols before storing in index

* fix: Add list copy of arg to maintain immutability